### PR TITLE
Clear GroupsDict on reload

### DIFF
--- a/Rocket/Rocket.Core/Permissions/RocketPermissionsManager.cs
+++ b/Rocket/Rocket.Core/Permissions/RocketPermissionsManager.cs
@@ -61,6 +61,7 @@ namespace Rocket.Core.Permissions
         public void Reload()
         {
             helper.permissions.Load();
+            helper.permissions.Instance.GroupsDict.Clear();
             foreach (RocketPermissionsGroup _Group in helper.permissions.Instance.Groups) helper.permissions.Instance.GroupsDict[_Group.Id] = _Group;
         }
 


### PR DESCRIPTION
Before populating it, so groups can be removed with /p reload. Otherwise deleted groups might stay as long as server is on.