### PR TITLE
Remove unnecessary .ToLower()

### DIFF
--- a/Rocket/Rocket.Core/Commands/RocketCommandManager.cs
+++ b/Rocket/Rocket.Core/Commands/RocketCommandManager.cs
@@ -169,7 +169,7 @@ namespace Rocket.Core.Commands
                     foreach (string Alias in command.Aliases)
                     {
                         if (string.IsNullOrEmpty(Alias)) continue;
-                        commandsDict[Alias] = commandsDict[mapping.Name.ToLower()];
+                        commandsDict[Alias] = commandsDict[mapping.Name];
                     }
                 }
                 Logging.Logger.Log("[registered] /" + mapping.Name.ToLower() + " (" + mapping.Class + ")", ConsoleColor.Green);


### PR DESCRIPTION
Should speed up command registrations a tiny tiny bit as well as save a tiny tiny bit of memory during command registration.