### PR TITLE
/rocket gc (easy fix so why not)

### DIFF
--- a/Rocket.Unturned/Commands/CommandRocket.cs
+++ b/Rocket.Unturned/Commands/CommandRocket.cs
@@ -94,6 +94,11 @@ namespace Rocket.Unturned.Commands
                         R.ReloadCmds();
                         UnturnedChat.Say(caller, U.Translate("command_rocket_reloaded_commands"));
                         break;
+                    case "gc":
+                        if (caller != null && !caller.HasPermission("rocket.gc")) return;
+                        R.Commands.ClearInactiveCooldowns();
+                        UnturnedChat.Say(caller, U.Translate("command_rocket_gc"));
+                        break;
                 }
             }
 

--- a/Rocket.Unturned/U.cs
+++ b/Rocket.Unturned/U.cs
@@ -109,6 +109,7 @@ namespace Rocket.Unturned
                 { "command_rocket_reload","Reloading Rocket"},
                 { "command_rocket_reload_disabled", "Please reload individual plugins instead" },
                 { "command_rocket_reloaded_commands", "Reloaded commands file. You may need to reload plugins to make sure newly enabled commands are loaded." },
+                { "command_rocket_gc", "Cleared inactive cooldowns." },
                 { "command_p_group_not_found","Group not found"},
                 { "command_p_group_player_added","{0} was added to the group {1}"},
                 { "command_p_group_player_removed","{0} was removed from from the group {1}"},


### PR DESCRIPTION
Clears memory leaks from the cooldown list when using /rocket gc. For those that may want it.
It was an easy fix so why not