### PR TITLE
Compatibility fixes

### DIFF
--- a/Rocket/Rocket.API/IRocketPermissionsProvider.cs
+++ b/Rocket/Rocket.API/IRocketPermissionsProvider.cs
@@ -15,12 +15,10 @@ namespace Rocket.API
 
         public static bool HasPermission(this IRocketPermissionsProvider rocketPermissionProvider, IRocketPlayer player, IRocketCommand command)
         {
-            HashSet<string> commandPermissions = new HashSet<string>(command.Permissions.Select(p => p.ToLower()));
-            commandPermissions.Add(command.Name.ToLower());
-            foreach (string alias in command.Aliases)
-            {
-                commandPermissions.Add(alias.ToLower());
-            }
+            List<string> commandPermissions = command.Permissions;
+            commandPermissions.Add(command.Name);
+            commandPermissions.AddRange(command.Aliases);
+            commandPermissions = commandPermissions.Select(a => a.ToLower()).ToList();
             return rocketPermissionProvider.HasPermission(player, commandPermissions);
         }
 
@@ -42,7 +40,7 @@ namespace Rocket.API
     public interface IRocketPermissionsProvider
     {
         bool HasPermission(IRocketPlayer player, List<string> requestedPermissions);
-        bool HasPermission(IRocketPlayer player, HashSet<string> requestedPermissions);
+        //bool HasPermission(IRocketPlayer player, HashSet<string> requestedPermissions);
 
         List<RocketPermissionsGroup> GetGroups(IRocketPlayer player, bool includeParentGroups);
         List<Permission> GetPermissions(IRocketPlayer player);
@@ -57,7 +55,8 @@ namespace Rocket.API
         RocketPermissionsProviderResult DeleteGroup(string groupId);
 
         void Reload();
+        /*
         void ManualLoad();
-        System.Collections.IEnumerator ManualUpdate();
+        System.Collections.IEnumerator ManualUpdate();*/
     }
 }

--- a/Rocket/Rocket.Core/Permissions/RocketPermissionsManager.cs
+++ b/Rocket/Rocket.Core/Permissions/RocketPermissionsManager.cs
@@ -64,7 +64,7 @@ namespace Rocket.Core.Permissions
             helper.permissions.Instance.GroupsDict.Clear();
             foreach (RocketPermissionsGroup _Group in helper.permissions.Instance.Groups) helper.permissions.Instance.GroupsDict[_Group.Id] = _Group;
         }
-
+        /*
         public void ManualLoad() { Awake(); }
         public System.Collections.IEnumerator ManualUpdate() {
             while (R.Settings.Instance.WebPermissions.Enabled)
@@ -88,7 +88,7 @@ namespace Rocket.Core.Permissions
                 yield return new WaitForSeconds(R.Settings.Instance.WebPermissions.Interval);
             }
             yield break;
-        }
+        }*/
 
         public bool HasPermission(IRocketPlayer player, List<string> permissions)
         {
@@ -99,10 +99,10 @@ namespace Rocket.Core.Permissions
         {
             return helper.HasPermission(playerId, permissions);
         }
-        public bool HasPermission(IRocketPlayer player, HashSet<string> requestedPermissions)
+        /*public bool HasPermission(IRocketPlayer player, HashSet<string> requestedPermissions)
         {
             return helper.HasPermission(player, requestedPermissions);
-        }
+        }*/
 
         public List<RocketPermissionsGroup> GetGroups(IRocketPlayer player, bool includeParentGroups)
         {

--- a/Rocket/Rocket.Core/R.cs
+++ b/Rocket/Rocket.Core/R.cs
@@ -72,14 +72,14 @@ namespace Rocket.Core
                 Settings = new XMLFileAsset<RocketSettings>(Environment.SettingsFile);
                 Translation = new XMLFileAsset<TranslationList>(String.Format(Environment.TranslationFile, Settings.Instance.LanguageCode), new Type[] { typeof(TranslationList), typeof(TranslationListEntry) }, defaultTranslations);
                 defaultTranslations.AddUnknownEntries(Translation);
-                Permissions = new RocketPermissionsManager();
+                Permissions = gameObject.TryAddComponent<RocketPermissionsManager>();
                 Plugins = gameObject.TryAddComponent<RocketPluginManager>();
                 Commands = gameObject.TryAddComponent<RocketCommandManager>();
-                Permissions.ManualLoad();
+                /*Permissions.ManualLoad();
                 if (Settings.Instance.WebPermissions.Enabled)
                 {
                     StartCoroutine(Permissions.ManualUpdate());
-                }
+                }*/
 
                 // Load Commands from Rocket.Core.Commands.
                 Commands.RegisterFromAssembly(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
AdvancedRegions and ShimmysAdminTools were using the IRocketPermissionsProvider, so I undid the modifications to that.
(AdvancedRegions incompatibility caused permissions to break completely)

I also re-added the .TryAddComponent<>() for permissions, but I changed Start() to Awake() and things are working as intended. Start() seemed to re-initialize every call.